### PR TITLE
ENH(CI): test PyPI wheel install/run under PyPy

### DIFF
--- a/.github/workflows/test-pypi-wheel.yaml
+++ b/.github/workflows/test-pypi-wheel.yaml
@@ -23,6 +23,16 @@ jobs:
           - windows-2022
           - macos-latest
           - macos-14
+        # Empty `python` means "let uv pick" (CPython by default).
+        python: [""]
+        include:
+          # The wheel is tagged `py3-none-<platform>`, which is implementation-
+          # agnostic. Verify it actually installs and runs under PyPy as well,
+          # so downstream PyPy users (e.g. datalad-installer) don't regress.
+          - os: ubuntu-latest
+            python: pypy@3.10
+          - os: macos-latest
+            python: pypy@3.10
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -30,8 +40,10 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install git-annex
+        env:
+          PYTHON_SPEC: ${{ matrix.python }}
         run: |
-          uv tool install git-annex
+          uv tool install ${PYTHON_SPEC:+--python "$PYTHON_SPEC"} git-annex
 
       - name: Which git-annex
         run: |


### PR DESCRIPTION
The wheel is tagged `py3-none-<platform>`, which is implementation- agnostic, so it should be installable under any Python 3 (incl. PyPy). Add a PyPy row on a Linux and OSX to the existing test-wheel matrix to verify this stays true and protect downstream PyPy users (e.g. datalad- installer) from silent regression.

Implemented as an `include` extension to the existing matrix (rather than a separate job) and a single `${PYTHON_SPEC:+--python "$PYTHON_SPEC"}` expansion in the install step, so default rows continue to let `uv` pick CPython.

Prompted by fails on tests in datalad-installer but it is more of an issue there... here just to ensure that all is good