### PR TITLE
Dual license packaging code under MIT/AGPL-3+

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -843,6 +843,25 @@ License: AGPL-3+
   For more information on this, and how to apply and follow the GNU AGPL, see
   <http://www.gnu.org/licenses/>.
 
+License: MIT
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the “Software”), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+	
+  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+
 Files: .github/*
 Copyright: © 2020- John T. Wodder II <git@varonathe.org>
            © 2020- Yaroslav Halchenko <debian@onerussian.com>
@@ -852,4 +871,4 @@ License: AGPL-3+
 Files: src/* hatch/*
 Copyright: © 2025- Michael Hanke <mih@ngln.eu>
            © 2025- Christopher J. Markiewicz <markiewicz@stanford.edu>
-License: AGPL-3+
+License: AGPL-3+ or MIT


### PR DESCRIPTION
To allow easy reuse of wrapping code in GPL and non-GPL projects.

I broadly applied to the `src/` and `hatch/` directories, but could narrow it if there's any reason to.

Supports https://github.com/bids-standard/bids-validator/pull/425.